### PR TITLE
Make the build system CI/CD-friendly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+**/.DS_Store
+
 .git/
 .vagrant/
 

--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,12 @@ KERNEL_VERSION  := 4.14.47
 BUSYBOX_VERSION := 1.28.4
 
 OUTPUTS := output/rootfs.tar.xz output/bzImage output/barge.iso output/barge.img
-SOURCES := Dockerfile .dockerignore \
-	$(shell find configs -type f) \
-	$(shell find overlay -type f) \
-	$(shell find patches -type f) \
-	$(shell find scripts -type f)
 
 BUILD_IMAGE     := barge-builder
 BUILD_CONTAINER := barge-built
 
-BUILT := `docker ps -aq -f name=$(BUILD_CONTAINER) -f exited=0`
-STR_CREATED := $$(docker inspect -f '{{.Created}}' $(BUILD_IMAGE) 2>/dev/null)
-IMG_CREATED := `date -j -u -f "%FT%T" "$(STR_CREATED)" +"%s" 2>/dev/null || echo 0`
+IS_BUILT := `docker ps -aq -f name=$(BUILD_CONTAINER) -f exited=0`
+IMAGE_ID := `docker inspect -f '{{.ID}}' $(BUILD_IMAGE) 2>/dev/null`
 
 DL_DIR     := /mnt/data/dl
 CCACHE_DIR := /mnt/data/ccache
@@ -23,17 +17,16 @@ all: $(OUTPUTS)
 $(OUTPUTS): build | output
 	docker cp $(BUILD_CONTAINER):/build/buildroot/output/images/$(@F) output/
 
-build: $(SOURCES)
-	$(eval SRC_UPDATED=$$(shell stat -f "%m" $^ | sort -gr | head -n1))
-	@if [ "$(SRC_UPDATED)" -gt "$(IMG_CREATED)" ]; then \
-		set -e; \
-		find . -type f -name '.DS_Store' | xargs rm -f; \
-		docker build -t $(BUILD_IMAGE) .; \
-		if [ "$(IMG_CREATED)" -gt "$(SRC_UPDATED)" ]; then \
-			(docker rm -f $(BUILD_CONTAINER) || true); \
-		fi; \
+build:
+	$(eval OLD_IMAGE_ID=$(IMAGE_ID))
+	docker build -t $(BUILD_IMAGE) .
+	@echo "$(OLD_IMAGE_ID)"
+	@echo "$(IMAGE_ID)"
+	@if [ "$(OLD_IMAGE_ID)" != "$(IMAGE_ID)" ]; then \
+		(docker rm -f $(BUILD_CONTAINER) || true); \
 	fi
-	@if [ "$(BUILT)" = "" ]; then \
+	@echo "$(IS_BUILT)"
+	@if [ "$(IS_BUILT)" = "" ]; then \
 		set -e; \
 		(docker rm -f $(BUILD_CONTAINER) || true); \
 		docker run --privileged -v $(DL_DIR):/build/buildroot/dl \

--- a/Makefile
+++ b/Makefile
@@ -44,23 +44,13 @@ output:
 	@mkdir -p $@
 
 clean:
-	$(RM) -r output
 	-docker rm -f $(BUILD_CONTAINER)
 
 distclean: clean
 	-docker rmi $(BUILD_IMAGE)
-	vagrant destroy -f
-	$(RM) -r .vagrant
+	$(RM) -r output
 
 .PHONY: all build clean distclean
-
-vagrant:
-	vagrant up barge
-	vagrant ssh barge -c 'sudo mkdir -p $(DL_DIR) $(CCACHE_DIR)'
-
-dev:
-	vagrant up barge-$@
-	vagrant ssh barge-$@ -c 'sudo mkdir -p $(DL_DIR) $(CCACHE_DIR)'
 
 config: | output
 	docker cp $(BUILD_CONTAINER):/build/buildroot/.config output/buildroot.config
@@ -70,12 +60,4 @@ config: | output
 	docker cp $(BUILD_CONTAINER):/build/buildroot/output/build/linux-$(KERNEL_VERSION)/.config output/kernel.config
 	-diff configs/kernel.config output/kernel.config
 
-install:
-	cp output/bzImage ../barge-packer/virtualbox/iso/
-	cp output/rootfs.tar.xz ../barge-packer/virtualbox/iso/
-	cp configs/kernel.config ../barge-packer/virtualbox/iso/
-	cp configs/isolinux.cfg ../barge-packer/virtualbox/iso/
-	cp output/barge.iso ../barge-packer/qemu/
-	cp output/barge.img ../barge-packer/qemu/
-
-.PHONY: vagrant dev config install
+.PHONY: config

--- a/docs/build.md
+++ b/docs/build.md
@@ -3,6 +3,7 @@
 ## Requirements
 
 - [Docker](https://www.docker.com/)
+- 2GB Memory to build Buildroot in a container
 
 Or we provide `Vagrantfile` to create a Docker environment in your local machine.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -11,7 +11,9 @@ Or we provide `Vagrantfile` to create a Docker environment in your local machine
 
 ## Building
 
-Primarily this build method assumes that you have Docker client.
+### 1. Build with your local Docker environment
+
+This build method assumes that you have a Docker environment, `docker` client and `make` locally.
 
 ```
 $ git clone https://github.com/bargees/barge
@@ -19,25 +21,41 @@ $ cd barge
 $ make
 ```
 
-Or if you don't have Docker but Vagrant,
+### 2. Build with Vagrant to create a Docker environment VM.
+
+If you don't have a Docker daemon to access from your local machine, you can create it with Vagrant.
 
 ```
 $ git clone https://github.com/bargees/barge
 $ cd barge
 $ vagrant up
+```
+
+And then if you have `make` and `docker` client in your local machine, just `make`.
+
+```
+$ make
+```
+
+Otherwise, you need to log into the VM.
+
+```
 $ vagrant ssh
+[bargee@barge ~]$ sudo pkg install make
 [bargee@barge ~]$ cd /vagrant/
 [bargee@barge vagrant]$ make
 ```
 
-It will create the following images at `./output/` directory.
+2 methods above will create the following images at `./output/` directory.
 
 - barge.iso: LiveCD image
 - barge.img: Bootable disk image
 - bzImage: Raw Linux kernel image
 - rootfs.tar.xz: Raw Root filesystem including Linux kernel modules and drivers
 
-Or you can use Docker client manually without `make`.
+### 3. Build with Docker manually
+
+In the above cases, you can use Docker client manually without `make` as well.
 
 ```
 $ docker build -t barge-builder .

--- a/docs/build.md
+++ b/docs/build.md
@@ -11,13 +11,23 @@ Or we provide `Vagrantfile` to create a Docker environment in your local machine
 
 ## Building
 
-Primarily this build method assumes that you have Docker client on Mac OS X.
+Primarily this build method assumes that you have Docker client.
 
 ```
 $ git clone https://github.com/bargees/barge
 $ cd barge
-$ vagrant up # if you don't have Docker.
 $ make
+```
+
+Or if you don't have Docker but Vagrant,
+
+```
+$ git clone https://github.com/bargees/barge
+$ cd barge
+$ vagrant up
+$ vagrant ssh
+[bargee@barge ~]$ cd /vagrant/
+[bargee@barge vagrant]$ make
 ```
 
 It will create the following images at `./output/` directory.
@@ -27,7 +37,7 @@ It will create the following images at `./output/` directory.
 - bzImage: Raw Linux kernel image
 - rootfs.tar.xz: Raw Root filesystem including Linux kernel modules and drivers
 
-Or you can use a Docker client manually without `make`.
+Or you can use Docker client manually without `make`.
 
 ```
 $ docker build -t barge-builder .

--- a/docs/build.md
+++ b/docs/build.md
@@ -2,6 +2,10 @@
 
 ## Requirements
 
+- [Docker](https://www.docker.com/)
+
+Or we provide `Vagrantfile` to create a Docker environment in your local machine.
+
 - [VirtualBox](https://www.virtualbox.org/)
 - [Vagrant](https://www.vagrantup.com/)
 
@@ -12,7 +16,7 @@ Primarily this build method assumes that you have Docker client on Mac OS X.
 ```
 $ git clone https://github.com/bargees/barge
 $ cd barge
-$ make vagrant
+$ vagrant up # if you don't have Docker.
 $ make
 ```
 
@@ -23,16 +27,11 @@ It will create the following images at `./output/` directory.
 - bzImage: Raw Linux kernel image
 - rootfs.tar.xz: Raw Root filesystem including Linux kernel modules and drivers
 
-Or you can use Docker client on the VM manually after `make vagrant`.
+Or you can use a Docker client manually without `make`.
 
 ```
-$ make vagrant
-$ vagrant ssh
-[bargee@barge ~]$ cd /vagrant/
-[bargee@barge vagrant]$ mkdir -p output dl
-[bargee@barge vagrant]$ docker build -t barge-builder .
-[bargee@barge vagrant]$ docker run --privileged -v /mnt/data/ccache:/build/buildroot/ccache \
-  -v /vagrant/dl:/build/buildroot/dl --name barge-built barge-builder
-[bargee@barge vagrant]$ docker cp barge-built:/build/buildroot/output/images/barge.iso output/
-[bargee@barge vagrant]$ exit
+$ docker build -t barge-builder .
+$ docker run --privileged --name barge-built barge-builder
+$ mkdir -p output
+$ docker cp barge-built:/build/buildroot/output/images/barge.iso output/
 ```


### PR DESCRIPTION
- Remove Vagrant dependency
- Don’t use non-interoperable commands (`stat` and `date`)  
  Please maintain .dockerignore file accordingly instead.

Cf.) https://github.com/bargees/barge-os/issues/81

ping @prologic 